### PR TITLE
Fix formatter script to assert successful `nimpretty` exit status

### DIFF
--- a/tools/run_formatter/run_formatter.nim
+++ b/tools/run_formatter/run_formatter.nim
@@ -4,4 +4,4 @@ const LIBRARY_ROOT = "../src/cplib/"
 for filename in walkDirRec(LIBRARY_ROOT):
     if not filename.endsWith(".nim"): continue
     var command = &"nimpretty --maxLineLen:300 {filename.absolutePath}"
-    assert execShellCmd(command) != 0, &"{command} end with non-zero status code"
+    assert execShellCmd(command) == 0, &"{command} end with non-zero status code"


### PR DESCRIPTION
### Motivation
- The formatter runner was asserting a non-zero exit status which treated successful `nimpretty` runs as failures, so the check needed to be inverted to detect real errors.

### Description
- Change the assertion in `tools/run_formatter/run_formatter.nim` from `execShellCmd(command) != 0` to `execShellCmd(command) == 0` so the script requires `nimpretty` to exit with status zero.

### Testing
- Ran the formatter script `tools/run_formatter/run_formatter.nim` against the library files and the script completed with the assertion passing (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54825c934832a95f4e46b4c8ca830)