### PR TITLE
[AI] Add Min-Plus Arithmetic

### DIFF
--- a/src/cplib/math/minplus.nim
+++ b/src/cplib/math/minplus.nim
@@ -1,0 +1,80 @@
+when not declared CPLIB_MATH_MINPLUS:
+    const CPLIB_MATH_MINPLUS* = 1
+
+    import hashes
+
+    type MinPlus*[T] = object
+        ## The min-plus (tropical) semiring.
+        ##
+        ## `+` is minimum, `*` is addition, `zero` is positive infinity,
+        ## and `one` is the underlying value zero.
+        value: T
+        finite: bool
+
+    proc initMinPlus*[T](value: T): MinPlus[T] {.inline.} =
+        MinPlus[T](value: value, finite: true)
+
+    converter toMinPlus*[T](value: T): MinPlus[T] {.inline.} =
+        initMinPlus(value)
+
+    proc infinity*[T](_: typedesc[MinPlus[T]]): MinPlus[T] {.inline.} =
+        default(MinPlus[T])
+
+    proc zero*[T](_: typedesc[MinPlus[T]]): MinPlus[T] {.inline.} =
+        default(MinPlus[T])
+
+    proc one*[T](_: typedesc[MinPlus[T]]): MinPlus[T] {.inline.} =
+        initMinPlus(T(0))
+
+    proc isFinite*[T](x: MinPlus[T]): bool {.inline.} = x.finite
+    proc isInfinity*[T](x: MinPlus[T]): bool {.inline.} = not x.finite
+
+    proc val*[T](x: MinPlus[T]): T {.inline.} =
+        ## Returns the underlying value. Infinity has no value.
+        assert x.finite, "min-plus infinity has no finite value"
+        x.value
+
+    proc get*[T](x: MinPlus[T], fallback: T): T {.inline.} =
+        if x.finite: x.value else: fallback
+
+    proc `$`*[T](x: MinPlus[T]): string =
+        if x.finite: $x.value else: "inf"
+
+    proc `==`*[T](a, b: MinPlus[T]): bool {.inline.} =
+        a.finite == b.finite and (not a.finite or a.value == b.value)
+
+    proc `<`*[T](a, b: MinPlus[T]): bool {.inline.} =
+        if not b.finite: a.finite
+        elif not a.finite: false
+        else: a.value < b.value
+
+    proc `<=`*[T](a, b: MinPlus[T]): bool {.inline.} = a < b or a == b
+    proc `>`*[T](a, b: MinPlus[T]): bool {.inline.} = b < a
+    proc `>=`*[T](a, b: MinPlus[T]): bool {.inline.} = b <= a
+
+    proc `+`*[T](a, b: MinPlus[T]): MinPlus[T] {.inline.} =
+        if a <= b: a else: b
+
+    proc `+=`*[T](a: var MinPlus[T], b: MinPlus[T]) {.inline.} = a = a + b
+
+    proc `*`*[T](a, b: MinPlus[T]): MinPlus[T] {.inline.} =
+        if a.finite and b.finite: initMinPlus(a.value + b.value)
+        else: MinPlus[T].zero
+
+    proc `*=`*[T](a: var MinPlus[T], b: MinPlus[T]) {.inline.} = a = a * b
+
+    proc pow*[T](a: MinPlus[T], exponent: Natural): MinPlus[T] =
+        result = MinPlus[T].one
+        var a = a
+        var exponent = exponent
+        while exponent > 0:
+            if (exponent and 1) == 1: result *= a
+            a *= a
+            exponent = exponent shr 1
+
+    proc `^`*[T](a: MinPlus[T], exponent: Natural): MinPlus[T] {.inline.} =
+        a.pow(exponent)
+
+    proc hash*[T](x: MinPlus[T]): Hash =
+        if x.finite: hash(x.value) !& Hash(1)
+        else: Hash(0)

--- a/src/verify/AI/minplus_test.nim
+++ b/src/verify/AI/minplus_test.nim
@@ -1,0 +1,27 @@
+# verification-helper: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ITP1_1_A
+echo "Hello World"
+
+import cplib/math/minplus
+import sets
+
+type M = MinPlus[int]
+
+let inf = M.infinity
+let a: M = 3
+let b: M = -2
+
+assert inf.isInfinity
+assert not a.isInfinity
+assert a.val == 3
+assert inf.get(100) == 100
+assert $inf == "inf"
+assert (a + b).val == -2
+assert (a * b).val == 1
+assert a + inf == a
+assert a * inf == inf
+assert M.zero == inf
+assert M.one.val == 0
+assert (a ^ 3).val == 9
+assert inf ^ 0 == M.one
+assert b < a and a < inf
+assert toHashSet([a, b, inf, a]).len == 3


### PR DESCRIPTION
## Summary

- Add Min-Plus Arithmetic for competitive programming.
- Add or update focused verification programs for the public behavior.

## Public API

- `src/cplib/math/minplus.nim`

## Verification

- `src/verify/AI/minplus_test.nim`

Checks performed:

- `git diff --check`
- Corresponding verify programs compile with `nim cpp -d:release --path:src`.
- Self-contained AI/ITP1 verification programs were executed where applicable.

Closes #567 