### PR TITLE
[AI] Add Integer K-th Root

### DIFF
--- a/src/cplib/math/kth_root_integer.nim
+++ b/src/cplib/math/kth_root_integer.nim
@@ -1,0 +1,52 @@
+when not declared CPLIB_MATH_KTH_ROOT_INTEGER:
+    const CPLIB_MATH_KTH_ROOT_INTEGER* = 1
+
+    proc power_leq(base: uint64, exponent: int, limit: uint64): bool =
+        ## Returns whether `base ^ exponent <= limit` without overflowing uint64.
+        var
+            base = base
+            exponent = exponent
+            product = 1'u64
+        while exponent > 0:
+            if (exponent and 1) != 0:
+                if base != 0 and product > limit div base:
+                    return false
+                product *= base
+            exponent = exponent shr 1
+            if exponent > 0:
+                if base != 0 and base > limit div base:
+                    return false
+                base *= base
+        return product <= limit
+
+    proc kth_root_integer*(a: uint64, k: int): uint64 =
+        ## Returns floor(a^(1/k)).
+        ##
+        ## `a` may use the entire uint64 range. `k` must be positive.
+        doAssert k >= 1
+        if a == 0 or k == 1:
+            return a
+
+        var
+            bit_length = 0
+            value = a
+        while value != 0:
+            bit_length += 1
+            value = value shr 1
+
+        if k >= bit_length:
+            return 1
+
+        # The answer is smaller than 2^ceil(bit_length / k). Since k >= 2
+        # here, the shift is at most 32 and is representable by uint64.
+        let root_bits = (bit_length + k - 1) div k
+        var
+            ok = 1'u64 shl (root_bits - 1)
+            ng = 1'u64 shl root_bits
+        while ng - ok > 1:
+            let mid = ok + (ng - ok) div 2
+            if power_leq(mid, k, a):
+                ok = mid
+            else:
+                ng = mid
+        return ok

--- a/src/verify/AI/kth_root_integer_test.nim
+++ b/src/verify/AI/kth_root_integer_test.nim
@@ -1,0 +1,17 @@
+# verification-helper: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ITP1_1_A
+echo "Hello World"
+
+import cplib/math/kth_root_integer
+
+assert kth_root_integer(0'u64, 1) == 0
+assert kth_root_integer(0'u64, 64) == 0
+assert kth_root_integer(1'u64, 64) == 1
+assert kth_root_integer(15'u64, 2) == 3
+assert kth_root_integer(16'u64, 2) == 4
+assert kth_root_integer(26'u64, 3) == 2
+assert kth_root_integer(27'u64, 3) == 3
+assert kth_root_integer(1'u64 shl 63, 63) == 2
+assert kth_root_integer((1'u64 shl 63) - 1, 63) == 1
+assert kth_root_integer(uint64.high, 1) == uint64.high
+assert kth_root_integer(uint64.high, 2) == 4_294_967_295'u64
+assert kth_root_integer(uint64.high, 64) == 1

--- a/src/verify/math/kth_root_integer_yosupo_test.nim
+++ b/src/verify/math/kth_root_integer_yosupo_test.nim
@@ -1,0 +1,17 @@
+# verification-helper: PROBLEM https://judge.yosupo.jp/problem/kth_root_integer
+import cplib/math/kth_root_integer
+import strutils
+
+proc scanf(formatstr: cstring) {.header: "<stdio.h>", varargs.}
+
+var t: int
+scanf("%d", addr t)
+var answers = newSeq[string](t)
+for i in 0..<t:
+    var
+        a: uint64
+        k: int
+    scanf("%llu %d", addr a, addr k)
+    answers[i] = $kth_root_integer(a, k)
+stdout.write(answers.join("\n"))
+stdout.write("\n")


### PR DESCRIPTION
## Summary

- Add Integer K-th Root for competitive programming.
- Add or update focused verification programs for the public behavior.

## Public API

- `src/cplib/math/kth_root_integer.nim`

## Verification

- `src/verify/AI/kth_root_integer_test.nim`
- `src/verify/math/kth_root_integer_yosupo_test.nim`

Checks performed:

- `git diff --check`
- Corresponding verify programs compile with `nim cpp -d:release --path:src`.
- Self-contained AI/ITP1 verification programs were executed where applicable.

Closes #300