### PR TITLE
[AI] Add Aho-Corasick

### DIFF
--- a/src/cplib/str/aho_corasick.nim
+++ b/src/cplib/str/aho_corasick.nim
@@ -1,0 +1,116 @@
+when not declared CPLIB_STR_AHO_CORASICK:
+    const CPLIB_STR_AHO_CORASICK* = 1
+
+    import std/[deques, tables]
+
+    type AhoCorasickState*[T] = object
+        ## Trie edges, failure link, and pattern ids matched at this state.
+        next*: Table[T, int]
+        failure*: int
+        output*: seq[int]
+        terminal: seq[int]
+
+    type AhoCorasick*[T] = object
+        states*: seq[AhoCorasickState[T]]
+        patternCount*: int
+        built*: bool
+
+    proc newState[T](): AhoCorasickState[T] =
+        result.next = initTable[T, int]()
+        result.failure = 0
+        result.output = @[]
+        result.terminal = @[]
+
+    proc initAhoCorasick*[T](): AhoCorasick[T] =
+        ## Initializes an empty pattern matching automaton.
+        result.states = @[newState[T]()]
+
+    proc addPattern*[T](ac: var AhoCorasick[T], pattern: openArray[T]): int =
+        ## Adds a pattern and returns its zero-based id.
+        ## Duplicate and empty patterns are allowed and receive distinct ids.
+        if ac.states.len == 0:
+            ac = initAhoCorasick[T]()
+        result = ac.patternCount
+        inc ac.patternCount
+        var state = 0
+        for c in pattern:
+            if not ac.states[state].next.hasKey(c):
+                ac.states[state].next[c] = ac.states.len
+                ac.states.add(newState[T]())
+            state = ac.states[state].next[c]
+        ac.states[state].terminal.add(result)
+        ac.built = false
+
+    proc build*[T](ac: var AhoCorasick[T]) =
+        ## Builds all failure links and inherited outputs.
+        ## It is safe to rebuild after adding more patterns.
+        if ac.states.len == 0:
+            ac = initAhoCorasick[T]()
+        for state in ac.states.mitems:
+            state.failure = 0
+            state.output = state.terminal
+
+        var queue = initDeque[int]()
+        for _, child in ac.states[0].next.pairs:
+            queue.addLast(child)
+
+        while queue.len > 0:
+            let v = queue.popFirst()
+            let failure = ac.states[v].failure
+            ac.states[v].output.add(ac.states[failure].output)
+            for c, child in ac.states[v].next.pairs:
+                var fallback = failure
+                while fallback != 0 and not ac.states[fallback].next.hasKey(c):
+                    fallback = ac.states[fallback].failure
+                if ac.states[fallback].next.hasKey(c):
+                    fallback = ac.states[fallback].next[c]
+                ac.states[child].failure = fallback
+                queue.addLast(child)
+        ac.built = true
+
+    proc requireBuilt[T](ac: AhoCorasick[T]) =
+        if not ac.built:
+            raise newException(ValueError, "AhoCorasick.build must be called first")
+
+    proc nextState*[T](ac: AhoCorasick[T], state: int, c: T): int =
+        ## Advances one symbol from `state` using failure links.
+        ac.requireBuilt()
+        if state < 0 or state >= ac.states.len:
+            raise newException(IndexDefect, "AhoCorasick state is out of bounds")
+        result = state
+        while result != 0 and not ac.states[result].next.hasKey(c):
+            result = ac.states[result].failure
+        if ac.states[result].next.hasKey(c):
+            result = ac.states[result].next[c]
+
+    proc matches*[T](ac: AhoCorasick[T], state: int): seq[int] =
+        ## Returns the ids of all patterns ending at `state`.
+        ac.requireBuilt()
+        if state < 0 or state >= ac.states.len:
+            raise newException(IndexDefect, "AhoCorasick state is out of bounds")
+        return ac.states[state].output
+
+    proc findAll*[T](ac: AhoCorasick[T], text: openArray[T]):
+            seq[tuple[position, patternId: int]] =
+        ## Returns every match as (inclusive end position, pattern id).
+        ## Empty patterns match at position -1 and after every input symbol.
+        ac.requireBuilt()
+        for patternId in ac.states[0].output:
+            result.add((-1, patternId))
+        var state = 0
+        for position, c in text:
+            state = ac.nextState(state, c)
+            for patternId in ac.states[state].output:
+                result.add((position, patternId))
+
+    proc countOccurrences*[T](ac: AhoCorasick[T], text: openArray[T]): seq[int] =
+        ## Counts possibly overlapping occurrences for every added pattern.
+        ac.requireBuilt()
+        result = newSeq[int](ac.patternCount)
+        for patternId in ac.states[0].output:
+            inc result[patternId]
+        var state = 0
+        for c in text:
+            state = ac.nextState(state, c)
+            for patternId in ac.states[state].output:
+                inc result[patternId]

--- a/src/verify/AI/aho_corasick_test.nim
+++ b/src/verify/AI/aho_corasick_test.nim
@@ -1,3 +1,6 @@
+# verification-helper: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ITP1_1_A
+echo "Hello World"
+
 import cplib/str/aho_corasick
 
 block basicString:

--- a/src/verify/AI/aho_corasick_test.nim
+++ b/src/verify/AI/aho_corasick_test.nim
@@ -1,0 +1,59 @@
+import cplib/str/aho_corasick
+
+block basicString:
+    var ac = initAhoCorasick[char]()
+    let he = ac.addPattern("he")
+    let she = ac.addPattern("she")
+    let his = ac.addPattern("his")
+    let hers = ac.addPattern("hers")
+    ac.build()
+
+    assert ac.patternCount == 4
+    assert ac.countOccurrences("ahishers") == @[1, 1, 1, 1]
+    assert ac.findAll("ahishers") == @[
+        (position: 3, patternId: his),
+        (position: 5, patternId: she),
+        (position: 5, patternId: he),
+        (position: 7, patternId: hers)
+    ]
+
+block overlapDuplicateAndEmpty:
+    var ac = initAhoCorasick[char]()
+    discard ac.addPattern("a")
+    discard ac.addPattern("aa")
+    discard ac.addPattern("a")
+    discard ac.addPattern("")
+    ac.build()
+    assert ac.countOccurrences("aaa") == @[3, 2, 3, 4]
+
+block genericSymbolsAndRebuild:
+    var ac = initAhoCorasick[int]()
+    discard ac.addPattern([1, 2])
+    ac.build()
+    assert ac.countOccurrences([1, 2, 1, 2]) == @[2]
+    discard ac.addPattern([2, 1])
+    ac.build()
+    assert ac.countOccurrences([1, 2, 1, 2]) == @[2, 1]
+
+block compareWithBruteForce:
+    let patterns = @["", "a", "b", "aa", "aba", "bab"]
+    var ac = initAhoCorasick[char]()
+    for pattern in patterns:
+        discard ac.addPattern(pattern)
+    ac.build()
+    for n in 0..8:
+        for mask in 0..<(1 shl n):
+            var text = newString(n)
+            for i in 0..<n:
+                text[i] = "ab"[(mask shr i) and 1]
+            var expected = newSeq[int](patterns.len)
+            for id, pattern in patterns:
+                if pattern.len == 0:
+                    expected[id] = n + 1
+                elif pattern.len <= n:
+                    for i in 0..n - pattern.len:
+                        if text[i..<i + pattern.len] == pattern:
+                            inc expected[id]
+            assert ac.countOccurrences(text) == expected
+
+echo "ok"


### PR DESCRIPTION
## Summary

- Add Aho-Corasick for competitive programming.
- Add or update focused verification programs for the public behavior.

## Public API

- `src/cplib/str/aho_corasick.nim`

## Verification

- `src/verify/AI/aho_corasick_test.nim`

Checks performed:

- `git diff --check`
- Corresponding verify programs compile with `nim cpp -d:release --path:src`.
- Self-contained AI/ITP1 verification programs were executed where applicable.

Closes #396