### PR TITLE
[AI] Add Rollback Mo

### DIFF
--- a/src/cplib/utils/rollback_mo.nim
+++ b/src/cplib/utils/rollback_mo.nim
@@ -1,0 +1,79 @@
+when not declared CPLIB_UTILS_ROLLBACK_MO:
+    const CPLIB_UTILS_ROLLBACK_MO* = 1
+    import std/[algorithm, math]
+
+    type
+        RollbackMoQuery = tuple[l, r, idx: int]
+        RollbackMo* = object
+            ## Mo's algorithm for data structures which support rollback.
+            ## Every query represents the half-open interval [l, r).
+            width*: int
+            N, Q: int
+            queries: seq[RollbackMoQuery]
+
+    proc initRollbackMo*(N, Q: int,
+            width = max(1, int(float(N) / max(1.0, sqrt(float(Q)))))): RollbackMo =
+        ## Creates a solver for an array of length `N` and at most `Q` queries.
+        doAssert N >= 0
+        doAssert Q >= 0
+        doAssert width > 0
+        result.N = N
+        result.Q = Q
+        result.width = width
+        result.queries = newSeqOfCap[RollbackMoQuery](Q)
+
+    proc insert*(self: var RollbackMo, l, r: int) =
+        ## Adds [l, r). Answers are indexed in insertion order.
+        doAssert 0 <= l and l <= r and r <= self.N
+        doAssert self.queries.len < self.Q
+        self.queries.add((l, r, self.queries.len))
+
+    proc run*[ADD, SNAPSHOT, ROLLBACK, REM](self: var RollbackMo,
+            add: ADD, snapshot: SNAPSHOT, rollback: ROLLBACK, rem: REM) =
+        ## Runs all inserted queries.
+        ##
+        ## `add(i)` inserts element i into the current state. `snapshot()`
+        ## returns an arbitrary state token, and `rollback(token)` restores it.
+        ## `rem(queryIndex)` records the answer for the current state.
+        var queries = self.queries
+        let width = self.width
+        queries.sort(proc(a, b: RollbackMoQuery): int =
+            let ab = a.l div width
+            let bb = b.l div width
+            if ab != bb: cmp(ab, bb)
+            else: cmp(a.r, b.r)
+        )
+
+        var first = 0
+        while first < queries.len:
+            let blockId = queries[first].l div self.width
+            let blockEnd = min(self.N, (blockId + 1) * self.width)
+            var last = first + 1
+            while last < queries.len and queries[last].l div self.width == blockId:
+                last.inc
+
+            # Queries contained in the left block are handled independently.
+            var pos = first
+            while pos < last and queries[pos].r <= blockEnd:
+                let state = snapshot()
+                for i in queries[pos].l..<queries[pos].r:
+                    add(i)
+                rem(queries[pos].idx)
+                rollback(state)
+                pos.inc
+
+            # The right part only grows. The left part is rolled back per query.
+            let blockState = snapshot()
+            var right = blockEnd
+            while pos < last:
+                while right < queries[pos].r:
+                    add(right)
+                    right.inc
+                let state = snapshot()
+                for i in countdown(blockEnd - 1, queries[pos].l):
+                    add(i)
+                rem(queries[pos].idx)
+                rollback(state)
+                pos.inc
+            rollback(blockState)
+            first = last

--- a/src/verify/AI/rollback_mo_test.nim
+++ b/src/verify/AI/rollback_mo_test.nim
@@ -1,0 +1,38 @@
+# verification-helper: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ITP1_1_A
+echo "Hello World"
+
+import cplib/utils/rollback_mo
+
+let a = @[3, 1, 4, 1, 5, 9, 2, 6]
+let ranges = @[(0, 2), (1, 7), (2, 5), (0, 8), (4, 4), (5, 8)]
+var solver = initRollbackMo(a.len, ranges.len, 3)
+for (l, r) in ranges:
+    solver.insert(l, r)
+
+var
+    sum = 0
+    history: seq[int]
+    ans = newSeq[int](ranges.len)
+
+proc addItem(i: int) =
+    history.add(sum)
+    sum += a[i]
+
+proc snapshot(): int = history.len
+
+proc rollback(state: int) =
+    while history.len > state:
+        sum = history.pop()
+
+proc rem(idx: int) = ans[idx] = sum
+
+solver.run(addItem, snapshot, rollback, rem)
+
+for i, query in ranges:
+    var expected = 0
+    for j in query[0]..<query[1]:
+        expected += a[j]
+    assert ans[i] == expected
+
+assert history.len == 0
+assert sum == 0


### PR DESCRIPTION
## Summary

- Add Rollback Mo for competitive programming.
- Add or update focused verification programs for the public behavior.

## Public API

- `src/cplib/utils/rollback_mo.nim`

## Verification

- `src/verify/AI/rollback_mo_test.nim`

Checks performed:

- `git diff --check`
- Corresponding verify programs compile with `nim cpp -d:release --path:src`.
- Self-contained AI/ITP1 verification programs were executed where applicable.


Closes https://github.com/kemuniku/cplib/issues/501
