### PR TITLE
[AI] Add Rollback Mo with Delete

### DIFF
--- a/src/cplib/utils/rollback_mo_delete.nim
+++ b/src/cplib/utils/rollback_mo_delete.nim
@@ -1,0 +1,74 @@
+when not declared CPLIB_UTILS_ROLLBACK_MO_DELETE:
+    const CPLIB_UTILS_ROLLBACK_MO_DELETE* = 1
+    import std/[algorithm, math]
+
+    type
+        RollbackMoDeleteQuery = tuple[l, r, idx: int]
+        RollbackMoDelete* = object
+            ## Rollback Mo for states which support deletion, but not insertion.
+            ## Every query represents the half-open interval [l, r).
+            width*: int
+            N, Q: int
+            queries: seq[RollbackMoDeleteQuery]
+
+    proc initRollbackMoDelete*(N, Q: int,
+            width = max(1, int(float(N) / max(1.0, sqrt(float(Q)))))): RollbackMoDelete =
+        ## Creates a solver for an array of length `N` and at most `Q` queries.
+        doAssert N >= 0
+        doAssert Q >= 0
+        doAssert width > 0
+        result.N = N
+        result.Q = Q
+        result.width = width
+        result.queries = newSeqOfCap[RollbackMoDeleteQuery](Q)
+
+    proc insert*(self: var RollbackMoDelete, l, r: int) =
+        ## Adds [l, r). Answers are indexed in insertion order.
+        doAssert 0 <= l and l <= r and r <= self.N
+        doAssert self.queries.len < self.Q
+        self.queries.add((l, r, self.queries.len))
+
+    proc run*[DEL, SNAPSHOT, ROLLBACK, REM](self: var RollbackMoDelete,
+            del: DEL, snapshot: SNAPSHOT, rollback: ROLLBACK, rem: REM) =
+        ## Runs all inserted queries. The initial state must contain [0, N).
+        ##
+        ## `del(i)` removes element i from the current state. `snapshot()`
+        ## returns an arbitrary state token, and `rollback(token)` restores it.
+        ## `rem(queryIndex)` records the answer for the current state. On return,
+        ## the initial state containing every element has been restored.
+        var queries = self.queries
+        let width = self.width
+        queries.sort(proc(a, b: RollbackMoDeleteQuery): int =
+            let ab = a.l div width
+            let bb = b.l div width
+            if ab != bb: cmp(ab, bb)
+            else: cmp(b.r, a.r)
+        )
+
+        var first = 0
+        while first < queries.len:
+            let blockId = queries[first].l div width
+            let blockStart = blockId * width
+            var last = first + 1
+            while last < queries.len and queries[last].l div width == blockId:
+                last.inc
+
+            let blockState = snapshot()
+            for i in 0..<blockStart:
+                del(i)
+
+            # The suffix only grows as right moves to the left. Deletions in the
+            # left block are temporary and are rolled back after each query.
+            var right = self.N
+            for pos in first..<last:
+                while right > queries[pos].r:
+                    right.dec
+                    del(right)
+                let state = snapshot()
+                for i in blockStart..<queries[pos].l:
+                    del(i)
+                rem(queries[pos].idx)
+                rollback(state)
+
+            rollback(blockState)
+            first = last

--- a/src/verify/AI/rollback_mo_delete_test.nim
+++ b/src/verify/AI/rollback_mo_delete_test.nim
@@ -1,0 +1,38 @@
+# verification-helper: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ITP1_1_A
+echo "Hello World"
+
+import cplib/utils/rollback_mo_delete
+
+let a = @[3, 1, 4, 1, 5, 9, 2, 6]
+let ranges = @[(0, 2), (1, 7), (2, 5), (0, 8), (4, 4), (5, 8)]
+var solver = initRollbackMoDelete(a.len, ranges.len, 3)
+for (l, r) in ranges:
+    solver.insert(l, r)
+
+var
+    sum = 31
+    history: seq[int]
+    ans = newSeq[int](ranges.len)
+
+proc deleteItem(i: int) =
+    history.add(sum)
+    sum -= a[i]
+
+proc snapshot(): int = history.len
+
+proc rollback(state: int) =
+    while history.len > state:
+        sum = history.pop()
+
+proc rem(idx: int) = ans[idx] = sum
+
+solver.run(deleteItem, snapshot, rollback, rem)
+
+for i, query in ranges:
+    var expected = 0
+    for j in query[0]..<query[1]:
+        expected += a[j]
+    assert ans[i] == expected
+
+assert history.len == 0
+assert sum == 31


### PR DESCRIPTION
## Summary

- Add Rollback Mo with Delete for competitive programming.
- Add or update focused verification programs for the public behavior.

## Public API

- `src/cplib/utils/rollback_mo_delete.nim`

## Verification

- `src/verify/AI/rollback_mo_delete_test.nim`

Checks performed:

- `git diff --check`
- Corresponding verify programs compile with `nim cpp -d:release --path:src`.
- Self-contained AI/ITP1 verification programs were executed where applicable.
